### PR TITLE
Add packages for Yocto (honister)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -22,7 +22,7 @@ USER zondax
 WORKDIR /home/zondax
 
 RUN sudo apt-get update && sudo apt-get -y install \
-    lbzip2
+    lbzip2 liblz4-tool zstd
 
 ####################################
 ADD entrypoint.sh /home/zondax/entrypoint.sh


### PR DESCRIPTION
Tools we need to add for building `honister` version of Yocto:

-  `lz4c` 
- `pzstd` 
- `zstd`

Added `liblz4-tool` and `zstd` packages to the image