### PR TITLE
add dependency for buildroot

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get -y install curl python-is-python3 locales sudo zsh gdisk libssl-dev rsync bc
+    apt-get -y install curl python-is-python3 locales sudo zsh gdisk libssl-dev rsync bc device-tree-compiler
 
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
     apt-get -y install gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 \ 
     python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa \ 
     libsdl1.2-dev pylint3 xterm python3-subunit mesa-common-dev zstd liblz4-tool lbzip2 bzip2 gzip patch tar \
-    binutils perl file wget 
+    binutils perl file wget ccache
 
 RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /usr/bin/repo && chmod a+x /usr/bin/repo
 


### PR DESCRIPTION
this adds the package:
`device-tree-compiler`
that does not appear in the buildroot docs but is required